### PR TITLE
add 'string' tag to CandleStick api request

### DIFF
--- a/requests/rest/market/market_requests.go
+++ b/requests/rest/market/market_requests.go
@@ -17,9 +17,9 @@ type (
 	}
 	GetCandlesticks struct {
 		InstID string       `json:"instId"`
-		After  int64        `json:"after,omitempty"`
-		Before int64        `json:"before,omitempty"`
-		Limit  int64        `json:"limit,omitempty"`
+		After  int64        `json:"after,omitempty,string"`
+		Before int64        `json:"before,omitempty,string"`
+		Limit  int64        `json:"limit,omitempty,string"`
 		Bar    okex.BarSize `json:"bar,omitempty"`
 	}
 	GetTrades struct {


### PR DESCRIPTION
Because of missing 'string' tag, int64 variables in GetCandlesticks struct change to empty value after `okex.S2M(req)`.