### PR TITLE
fix:placeOrder struct field

### DIFF
--- a/requests/rest/trade/trade_requests.go
+++ b/requests/rest/trade/trade_requests.go
@@ -12,7 +12,7 @@ type (
 		ClOrdID    string            `json:"clOrdId,omitempty"`
 		Tag        string            `json:"tag,omitempty"`
 		ReduceOnly bool              `json:"reduceOnly,omitempty"`
-		Sz         int64             `json:"sz,string"`
+		Sz         float64           `json:"sz,string"`
 		Px         float64           `json:"px,omitempty,string"`
 		TdMode     okex.TradeMode    `json:"tdMode"`
 		Side       okex.OrderSide    `json:"side"`


### PR DESCRIPTION
when i create a order by `client.Rest.Trade.PlaceOrder(trandeOrderList)` not work, beacause Sz field is int64 type
In [https://www.okx.com/docs-v5/en/#rest-api-trade-place-order](url) Sz field is string type