### PR TITLE
Add Multi-Instrument Subscription and Custom Dialer Support

### DIFF
--- a/api/ws/client.go
+++ b/api/ws/client.go
@@ -70,7 +70,7 @@ func NewClient(ctx context.Context, apiKey, secretKey, passphrase string, url ma
 		conn:                make(map[bool]*websocket.Conn),
 		dialer:              websocket.DefaultDialer,
 		lastTransmit:        make(map[bool]*time.Time),
-		mu:                  map[bool]*sync.RWMutex{true: new(sync.RWMutex), false: new(sync.RWMutex)},
+		mu:                  map[bool]*sync.RWMutex{true: {}, false: {}},
 	}
 	c.Private = NewPrivate(c)
 	c.Public = NewPublic(c)

--- a/api/ws/client.go
+++ b/api/ws/client.go
@@ -377,37 +377,27 @@ func (c *ClientWs) process(data []byte, e *events.Basic) bool {
 		e := events.Error{}
 		_ = json.Unmarshal(data, &e)
 		if c.ErrChan != nil {
-			go func() {
-				c.ErrChan <- &e
-			}()
+			c.ErrChan <- &e
 		}
 		return true
 	case "subscribe":
 		e := events.Subscribe{}
 		_ = json.Unmarshal(data, &e)
 		if c.SubscribeChan != nil {
-			go func() {
-				c.SubscribeChan <- &e
-			}()
+			c.SubscribeChan <- &e
 		}
 		if c.StructuredEventChan != nil {
-			go func() {
-				c.StructuredEventChan <- e
-			}()
+			c.StructuredEventChan <- e
 		}
 		return true
 	case "unsubscribe":
 		e := events.Unsubscribe{}
 		_ = json.Unmarshal(data, &e)
 		if c.UnsubscribeCh != nil {
-			go func() {
-				c.UnsubscribeCh <- &e
-			}()
+			c.UnsubscribeCh <- &e
 		}
 		if c.StructuredEventChan != nil {
-			go func() {
-				c.StructuredEventChan <- e
-			}()
+			c.StructuredEventChan <- e
 		}
 		return true
 	case "login":
@@ -420,14 +410,10 @@ func (c *ClientWs) process(data []byte, e *events.Basic) bool {
 		e := events.Login{}
 		_ = json.Unmarshal(data, &e)
 		if c.LoginChan != nil {
-			go func() {
-				c.LoginChan <- &e
-			}()
+			c.LoginChan <- &e
 		}
 		if c.StructuredEventChan != nil {
-			go func() {
-				c.StructuredEventChan <- e
-			}()
+			c.StructuredEventChan <- e
 		}
 		return true
 	}
@@ -446,17 +432,13 @@ func (c *ClientWs) process(data []byte, e *events.Basic) bool {
 		e := events.Success{}
 		_ = json.Unmarshal(data, &e)
 		if c.SuccessChan != nil {
-			go func() {
-				c.SuccessChan <- &e
-			}()
+			c.SuccessChan <- &e
 		}
 		if c.StructuredEventChan != nil {
-			go func() {
-				c.StructuredEventChan <- e
-			}()
+			c.StructuredEventChan <- e
 		}
 		return true
 	}
-	go func() { c.RawEventChan <- e }()
+	c.RawEventChan <- e
 	return false
 }

--- a/api/ws/public.go
+++ b/api/ws/public.go
@@ -83,7 +83,7 @@ func (c *Public) UTickers(req requests.Tickers, rCh ...bool) error {
 }
 
 // OpenInterest
-// Retrieve the open interest. Data will by pushed every 3 seconds.
+// Retrieve the open interest. Data will be pushed every 3 seconds.
 //
 // https://www.okex.com/docs-v5/en/#websocket-api-public-channels-open-interest-channel
 func (c *Public) OpenInterest(req requests.OpenInterest, ch ...chan *public.OpenInterest) error {
@@ -106,7 +106,7 @@ func (c *Public) UOpenInterest(req requests.OpenInterest, rCh ...bool) error {
 }
 
 // Candlesticks
-// Retrieve the open interest. Data will by pushed every 3 seconds.
+// Retrieve the open interest. Data will be pushed every 3 seconds.
 //
 // https://www.okex.com/docs-v5/en/#websocket-api-public-channels-candlesticks-channel
 func (c *Public) Candlesticks(req requests.Candlesticks, ch ...chan *public.Candlesticks) error {
@@ -379,196 +379,232 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 		switch ch {
 		case "instruments":
 			e := public.Instruments{}
-			err := json.Unmarshal(data, &e)
-			if err != nil {
+			if err := json.Unmarshal(data, &e); err != nil {
 				return false
 			}
-			go func() {
-				if c.iCh != nil {
+			if c.iCh != nil {
+				go func() {
 					c.iCh <- &e
-				}
-				c.StructuredEventChan <- e
-			}()
+				}()
+			}
+			if c.StructuredEventChan != nil {
+				go func() {
+					c.StructuredEventChan <- e
+				}()
+			}
 			return true
 		case "tickers":
 			e := public.Tickers{}
-			err := json.Unmarshal(data, &e)
-			if err != nil {
+			if err := json.Unmarshal(data, &e); err != nil {
 				return false
 			}
-			go func() {
-				if c.tCh != nil {
+			if c.tCh != nil {
+				go func() {
 					c.tCh <- &e
-				}
-				c.StructuredEventChan <- e
-			}()
+				}()
+			}
+			if c.StructuredEventChan != nil {
+				go func() {
+					c.StructuredEventChan <- e
+				}()
+			}
 			return true
 		case "open-interest":
 			e := public.OpenInterest{}
-			err := json.Unmarshal(data, &e)
-			if err != nil {
+			if err := json.Unmarshal(data, &e); err != nil {
 				return false
 			}
-			go func() {
-				if c.oiCh != nil {
+			if c.oiCh != nil {
+				go func() {
 					c.oiCh <- &e
-				}
-				c.StructuredEventChan <- e
-			}()
+				}()
+			}
+			if c.StructuredEventChan != nil {
+				go func() {
+					c.StructuredEventChan <- e
+				}()
+			}
 			return true
 		case "trades":
 			e := public.Trades{}
-			err := json.Unmarshal(data, &e)
-			if err != nil {
+			if err := json.Unmarshal(data, &e); err != nil {
 				return false
 			}
-			go func() {
-				if c.trCh != nil {
+			if c.trCh != nil {
+				go func() {
 					c.trCh <- &e
-				}
-				c.StructuredEventChan <- e
-			}()
+				}()
+			}
+			if c.StructuredEventChan != nil {
+				go func() {
+					c.StructuredEventChan <- e
+				}()
+			}
 			return true
 		case "estimated-price":
 			e := public.EstimatedDeliveryExercisePrice{}
-			err := json.Unmarshal(data, &e)
-			if err != nil {
+			if err := json.Unmarshal(data, &e); err != nil {
 				return false
 			}
-			go func() {
-				if c.edepCh != nil {
+			if c.edepCh != nil {
+				go func() {
 					c.edepCh <- &e
-				}
-				c.StructuredEventChan <- e
-			}()
+				}()
+			}
+			if c.StructuredEventChan != nil {
+				go func() {
+					c.StructuredEventChan <- e
+				}()
+			}
 			return true
 		case "mark-price":
 			e := public.MarkPrice{}
-			err := json.Unmarshal(data, &e)
-			if err != nil {
+			if err := json.Unmarshal(data, &e); err != nil {
 				return false
 			}
-			go func() {
-				if c.mpCh != nil {
+			if c.mpCh != nil {
+				go func() {
 					c.mpCh <- &e
-				}
-				c.StructuredEventChan <- e
-			}()
+				}()
+			}
+			if c.StructuredEventChan != nil {
+				go func() {
+					c.StructuredEventChan <- e
+				}()
+			}
 			return true
 		case "price-limit":
 			e := public.PriceLimit{}
-			err := json.Unmarshal(data, &e)
-			if err != nil {
+			if err := json.Unmarshal(data, &e); err != nil {
 				return false
 			}
-			go func() {
-				if c.plCh != nil {
+			if c.plCh != nil {
+				go func() {
 					c.plCh <- &e
-				}
-				c.StructuredEventChan <- e
-			}()
+				}()
+			}
+			if c.StructuredEventChan != nil {
+				go func() {
+					c.StructuredEventChan <- e
+				}()
+			}
 			return true
 		case "opt-summary":
 			e := public.OPTIONSummary{}
-			err := json.Unmarshal(data, &e)
-			if err != nil {
+			if err := json.Unmarshal(data, &e); err != nil {
 				return false
 			}
-			go func() {
-				if c.osCh != nil {
+			if c.osCh != nil {
+				go func() {
 					c.osCh <- &e
-				}
-				c.StructuredEventChan <- e
-			}()
+				}()
+			}
+			if c.StructuredEventChan != nil {
+				go func() {
+					c.StructuredEventChan <- e
+				}()
+			}
 			return true
 		case "funding-rate":
-			e := public.OPTIONSummary{}
-			err := json.Unmarshal(data, &e)
-			if err != nil {
+			e := public.FundingRate{}
+			if err := json.Unmarshal(data, &e); err != nil {
 				return false
 			}
-			go func() {
-				if c.osCh != nil {
-					c.osCh <- &e
-				}
-				c.StructuredEventChan <- e
-			}()
+			if c.frCh != nil {
+				go func() {
+					c.frCh <- &e
+				}()
+			}
+			if c.StructuredEventChan != nil {
+				go func() {
+					c.StructuredEventChan <- e
+				}()
+			}
 			return true
 		case "index-tickers":
 			e := public.IndexTickers{}
-			err := json.Unmarshal(data, &e)
-			if err != nil {
+			if err := json.Unmarshal(data, &e); err != nil {
 				return false
 			}
-			go func() {
-				if c.itCh != nil {
+			if c.itCh != nil {
+				go func() {
 					c.itCh <- &e
-				}
-				c.StructuredEventChan <- e
-			}()
+				}()
+			}
+			if c.StructuredEventChan != nil {
+				go func() {
+					c.StructuredEventChan <- e
+				}()
+			}
 			return true
 		default:
-			// special cases
-			// market price candlestick channel
 			chName := fmt.Sprint(ch)
-			// market price channels
 			if strings.Contains(chName, "mark-price-candle") {
 				e := public.MarkPriceCandlesticks{}
-				err := json.Unmarshal(data, &e)
-				if err != nil {
+				if err := json.Unmarshal(data, &e); err != nil {
 					return false
 				}
-				go func() {
-					if c.mpcCh != nil {
+				if c.mpcCh != nil {
+					go func() {
 						c.mpcCh <- &e
-					}
-					c.StructuredEventChan <- e
-				}()
+					}()
+				}
+				if c.StructuredEventChan != nil {
+					go func() {
+						c.StructuredEventChan <- e
+					}()
+				}
 				return true
 			}
-			// index chandlestick channels
 			if strings.Contains(chName, "index-candle") {
 				e := public.IndexCandlesticks{}
-				err := json.Unmarshal(data, &e)
-				if err != nil {
+				if err := json.Unmarshal(data, &e); err != nil {
 					return false
 				}
-				go func() {
-					if c.icCh != nil {
+				if c.icCh != nil {
+					go func() {
 						c.icCh <- &e
-					}
-					c.StructuredEventChan <- e
-				}()
+					}()
+				}
+				if c.StructuredEventChan != nil {
+					go func() {
+						c.StructuredEventChan <- e
+					}()
+				}
 				return true
 			}
-			// candlestick channels
 			if strings.Contains(chName, "candle") {
 				e := public.Candlesticks{}
-				err := json.Unmarshal(data, &e)
-				if err != nil {
+				if err := json.Unmarshal(data, &e); err != nil {
 					return false
 				}
-				go func() {
-					if c.cCh != nil {
+				if c.cCh != nil {
+					go func() {
 						c.cCh <- &e
-					}
-					c.StructuredEventChan <- e
-				}()
+					}()
+				}
+				if c.StructuredEventChan != nil {
+					go func() {
+						c.StructuredEventChan <- e
+					}()
+				}
 				return true
 			}
-			// order book channels
 			if strings.Contains(chName, "books") {
 				e := public.OrderBook{}
-				err := json.Unmarshal(data, &e)
-				if err != nil {
+				if err := json.Unmarshal(data, &e); err != nil {
 					return false
 				}
-				go func() {
-					if c.obCh != nil {
+				if c.obCh != nil {
+					go func() {
 						c.obCh <- &e
-					}
-					c.StructuredEventChan <- e
-				}()
+					}()
+				}
+				if c.StructuredEventChan != nil {
+					go func() {
+						c.StructuredEventChan <- e
+					}()
+				}
 				return true
 			}
 		}

--- a/api/ws/public.go
+++ b/api/ws/public.go
@@ -248,17 +248,21 @@ func (c *Public) UPriceLimit(req requests.PriceLimit, rCh ...bool) error {
 }
 
 // OrderBook
-// Retrieve order book data.
+// Retrieve order book data for multiple instruments.
 //
 // Use books for 400 depth levels, book5 for 5 depth levels, books50-l2-tbt tick-by-tick 50 depth levels, and books-l2-tbt for tick-by-tick 400 depth levels.
 //
 // https://www.okex.com/docs-v5/en/#websocket-api-public-channels-order-book-channel
-func (c *Public) OrderBook(req requests.OrderBook, ch ...chan *public.OrderBook) error {
-	m := okex.S2M(req)
+func (c *Public) OrderBook(reqs []requests.OrderBook, ch ...chan *public.OrderBook) error {
 	if len(ch) > 0 {
 		c.obCh = ch[0]
 	}
-	return c.Subscribe(false, []okex.ChannelName{}, m)
+	var subscriptions []map[string]string
+	for _, req := range reqs {
+		m := okex.S2M(req)
+		subscriptions = append(subscriptions, m)
+	}
+	return c.Subscribe(false, []okex.ChannelName{}, subscriptions...)
 }
 
 // UOrderBook

--- a/api/ws/public.go
+++ b/api/ws/public.go
@@ -383,14 +383,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				return false
 			}
 			if c.iCh != nil {
-				go func() {
-					c.iCh <- &e
-				}()
+				c.iCh <- &e
 			}
 			if c.StructuredEventChan != nil {
-				go func() {
-					c.StructuredEventChan <- e
-				}()
+				c.StructuredEventChan <- e
 			}
 			return true
 		case "tickers":
@@ -399,14 +395,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				return false
 			}
 			if c.tCh != nil {
-				go func() {
-					c.tCh <- &e
-				}()
+				c.tCh <- &e
 			}
 			if c.StructuredEventChan != nil {
-				go func() {
-					c.StructuredEventChan <- e
-				}()
+				c.StructuredEventChan <- e
 			}
 			return true
 		case "open-interest":
@@ -415,14 +407,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				return false
 			}
 			if c.oiCh != nil {
-				go func() {
-					c.oiCh <- &e
-				}()
+				c.oiCh <- &e
 			}
 			if c.StructuredEventChan != nil {
-				go func() {
-					c.StructuredEventChan <- e
-				}()
+				c.StructuredEventChan <- e
 			}
 			return true
 		case "trades":
@@ -431,14 +419,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				return false
 			}
 			if c.trCh != nil {
-				go func() {
-					c.trCh <- &e
-				}()
+				c.trCh <- &e
 			}
 			if c.StructuredEventChan != nil {
-				go func() {
-					c.StructuredEventChan <- e
-				}()
+				c.StructuredEventChan <- e
 			}
 			return true
 		case "estimated-price":
@@ -447,14 +431,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				return false
 			}
 			if c.edepCh != nil {
-				go func() {
-					c.edepCh <- &e
-				}()
+				c.edepCh <- &e
 			}
 			if c.StructuredEventChan != nil {
-				go func() {
-					c.StructuredEventChan <- e
-				}()
+				c.StructuredEventChan <- e
 			}
 			return true
 		case "mark-price":
@@ -463,14 +443,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				return false
 			}
 			if c.mpCh != nil {
-				go func() {
-					c.mpCh <- &e
-				}()
+				c.mpCh <- &e
 			}
 			if c.StructuredEventChan != nil {
-				go func() {
-					c.StructuredEventChan <- e
-				}()
+				c.StructuredEventChan <- e
 			}
 			return true
 		case "price-limit":
@@ -479,14 +455,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				return false
 			}
 			if c.plCh != nil {
-				go func() {
-					c.plCh <- &e
-				}()
+				c.plCh <- &e
 			}
 			if c.StructuredEventChan != nil {
-				go func() {
-					c.StructuredEventChan <- e
-				}()
+				c.StructuredEventChan <- e
 			}
 			return true
 		case "opt-summary":
@@ -495,14 +467,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				return false
 			}
 			if c.osCh != nil {
-				go func() {
-					c.osCh <- &e
-				}()
+				c.osCh <- &e
 			}
 			if c.StructuredEventChan != nil {
-				go func() {
-					c.StructuredEventChan <- e
-				}()
+				c.StructuredEventChan <- e
 			}
 			return true
 		case "funding-rate":
@@ -511,14 +479,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				return false
 			}
 			if c.frCh != nil {
-				go func() {
-					c.frCh <- &e
-				}()
+				c.frCh <- &e
 			}
 			if c.StructuredEventChan != nil {
-				go func() {
-					c.StructuredEventChan <- e
-				}()
+				c.StructuredEventChan <- e
 			}
 			return true
 		case "index-tickers":
@@ -527,14 +491,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 				return false
 			}
 			if c.itCh != nil {
-				go func() {
-					c.itCh <- &e
-				}()
+				c.itCh <- &e
 			}
 			if c.StructuredEventChan != nil {
-				go func() {
-					c.StructuredEventChan <- e
-				}()
+				c.StructuredEventChan <- e
 			}
 			return true
 		default:
@@ -545,14 +505,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 					return false
 				}
 				if c.mpcCh != nil {
-					go func() {
-						c.mpcCh <- &e
-					}()
+					c.mpcCh <- &e
 				}
 				if c.StructuredEventChan != nil {
-					go func() {
-						c.StructuredEventChan <- e
-					}()
+					c.StructuredEventChan <- e
 				}
 				return true
 			}
@@ -562,14 +518,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 					return false
 				}
 				if c.icCh != nil {
-					go func() {
-						c.icCh <- &e
-					}()
+					c.icCh <- &e
 				}
 				if c.StructuredEventChan != nil {
-					go func() {
-						c.StructuredEventChan <- e
-					}()
+					c.StructuredEventChan <- e
 				}
 				return true
 			}
@@ -579,14 +531,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 					return false
 				}
 				if c.cCh != nil {
-					go func() {
-						c.cCh <- &e
-					}()
+					c.cCh <- &e
 				}
 				if c.StructuredEventChan != nil {
-					go func() {
-						c.StructuredEventChan <- e
-					}()
+					c.StructuredEventChan <- e
 				}
 				return true
 			}
@@ -596,14 +544,10 @@ func (c *Public) Process(data []byte, e *events.Basic) bool {
 					return false
 				}
 				if c.obCh != nil {
-					go func() {
-						c.obCh <- &e
-					}()
+					c.obCh <- &e
 				}
 				if c.StructuredEventChan != nil {
-					go func() {
-						c.StructuredEventChan <- e
-					}()
+					c.StructuredEventChan <- e
 				}
 				return true
 			}

--- a/examples/books.go
+++ b/examples/books.go
@@ -10,10 +10,20 @@ import (
 	"github.com/gorilla/websocket"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"time"
 )
 
 func main() {
+
+	// Start the pprof server
+	go func() {
+		log.Println("Starting pprof server on localhost:6060")
+		if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+			log.Fatalf("could not start pprof server: %v", err)
+		}
+	}()
+
 	apiKey := ""
 	secretKey := ""
 	passphrase := ""

--- a/examples/main.go
+++ b/examples/main.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
 	"github.com/amir-the-h/okex"
 	"github.com/amir-the-h/okex/api"
 	"github.com/amir-the-h/okex/events/public"
 	requests "github.com/amir-the-h/okex/requests/ws/public"
+	"github.com/gorilla/websocket"
 	"log"
+	"net/http"
+	"time"
 )
 
 func main() {
@@ -35,6 +39,11 @@ func main() {
 		{InstID: "UNI-USDT", Channel: "books"},
 	}
 
+	client.Ws.Public.SetDialer(&websocket.Dialer{
+		Proxy:            http.ProxyFromEnvironment,
+		HandshakeTimeout: 45 * time.Second,
+		TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},
+	})
 	obCh := make(chan *public.OrderBook)
 	err = client.Ws.Public.OrderBook(orderBookRequests, obCh)
 	if err != nil {

--- a/examples/main.go
+++ b/examples/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"github.com/amir-the-h/okex"
+	"github.com/amir-the-h/okex/api"
+	"github.com/amir-the-h/okex/events/public"
+	requests "github.com/amir-the-h/okex/requests/ws/public"
+	"log"
+)
+
+func main() {
+	apiKey := ""
+	secretKey := ""
+	passphrase := ""
+	ctx := context.Background()
+	client, err := api.NewClient(ctx, apiKey, secretKey, passphrase, okex.NormalServer)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	orderBookRequests := []requests.OrderBook{
+		{InstID: "BTC-USDT", Channel: "books"},
+		{InstID: "ETH-USDT", Channel: "books"},
+		{InstID: "LTC-USDT", Channel: "books"},
+		{InstID: "XRP-USDT", Channel: "books"},
+		{InstID: "EOS-USDT", Channel: "books"},
+		{InstID: "BCH-USDT", Channel: "books"},
+		{InstID: "ETC-USDT", Channel: "books"},
+		{InstID: "BSV-USDT", Channel: "books"},
+		{InstID: "TRX-USDT", Channel: "books"},
+		{InstID: "LINK-USDT", Channel: "books"},
+		{InstID: "ADA-USDT", Channel: "books"},
+		{InstID: "DOT-USDT", Channel: "books"},
+		{InstID: "UNI-USDT", Channel: "books"},
+	}
+
+	obCh := make(chan *public.OrderBook)
+	err = client.Ws.Public.OrderBook(orderBookRequests, obCh)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Listen for updates
+	for update := range obCh {
+		log.Printf("Received order book update: %+v\n", update)
+		insId, _ := update.Arg.Get("instId")
+		log.Printf("Instrument ID: %s\n", insId)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/amir-the-h/okex
 
-go 1.17
+go 1.21
 
 require github.com/gorilla/websocket v1.4.2


### PR DESCRIPTION
- Added functionality to subscribe to order books of multiple instruments in a single request.
Introduced an option to set a custom WebSocket dialer, which allows users to avoid overloading the default dialer. This is especially useful for those managing multiple exchanges.
- Fix data race: I identified a data race issue in the client. The race condition was specifically observed in the receiver and sender methods, concurrently accessing, and modifying the c.lastTransmit map without proper synchronization.
- resolves the issue of goroutine leaks in the client and public process methods.
- Handle channel operations without launching unnecessary goroutines